### PR TITLE
Fix malformed EDNS COOKIE length handling for bug #29

### DIFF
--- a/dns/handler.go
+++ b/dns/handler.go
@@ -1,6 +1,12 @@
 package dns
 
 import (
+	"encoding/hex"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+
 	"github.com/TenforwardAB/slog"
 	"github.com/miekg/dns"
 	"go53/config"
@@ -8,10 +14,6 @@ import (
 	"go53/internal"
 	"go53/security"
 	"go53/zone"
-	"log"
-	"net"
-	"strconv"
-	"strings"
 )
 
 func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
@@ -84,6 +86,13 @@ func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 
 	if opt != nil && opt.Version() != 0 {
 		m.SetRcode(r, dns.RcodeBadVers)
+		m.Authoritative = false
+		writeResponse(w, r, m)
+		return
+	}
+
+	if malformedEDNSCookie(opt) {
+		m.SetRcode(r, dns.RcodeFormatError)
 		m.Authoritative = false
 		writeResponse(w, r, m)
 		return
@@ -274,6 +283,27 @@ func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 
 	dnsutils.ApplyNSID(m, r)
 	writeResponse(w, r, m)
+}
+
+func malformedEDNSCookie(opt *dns.OPT) bool {
+	if opt == nil {
+		return false
+	}
+	for _, option := range opt.Option {
+		cookie, ok := option.(*dns.EDNS0_COOKIE)
+		if !ok {
+			continue
+		}
+		raw, err := hex.DecodeString(cookie.Cookie)
+		if err != nil {
+			return true
+		}
+		length := len(raw)
+		if length != 8 && (length < 16 || length > 40) {
+			return true
+		}
+	}
+	return false
 }
 
 func writeResponse(w dns.ResponseWriter, req *dns.Msg, resp *dns.Msg) {

--- a/dns/handler_test.go
+++ b/dns/handler_test.go
@@ -271,6 +271,46 @@ func TestHandleRequestEDNSBadVersion(t *testing.T) {
 	}
 }
 
+func TestHandleRequestRejectsMalformedEDNSCookie(t *testing.T) {
+	resetDNSHandlerTestConfig()
+	tests := []struct {
+		name   string
+		cookie string
+	}{
+		{name: "empty", cookie: ""},
+		{name: "short client cookie", cookie: "00010203040506"},
+		{name: "between client and server cookie", cookie: "000102030405060708"},
+		{name: "short server cookie", cookie: "000102030405060708090a0b0c0d0e"},
+		{name: "too long", cookie: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728"},
+		{name: "not hex", cookie: "not-hex"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := new(mdns.Msg)
+			req.SetQuestion("example.test.", mdns.TypeA)
+			req.SetEdns0(1232, false)
+			req.IsEdns0().Option = append(req.IsEdns0().Option, &mdns.EDNS0_COOKIE{
+				Code:   mdns.EDNS0COOKIE,
+				Cookie: tt.cookie,
+			})
+
+			w := &captureResponseWriter{}
+			handleRequest(w, req)
+
+			if w.msg == nil {
+				t.Fatalf("expected response")
+			}
+			if w.msg.Rcode != mdns.RcodeFormatError {
+				t.Fatalf("rcode = %s, want FORMERR", mdns.RcodeToString[w.msg.Rcode])
+			}
+			if w.msg.Authoritative {
+				t.Fatalf("malformed COOKIE FORMERR must not be authoritative")
+			}
+		})
+	}
+}
+
 func TestFinalizeResponseCapsUDPSizeAndTruncates(t *testing.T) {
 	resetDNSHandlerTestConfig()
 	config.AppConfig.Live.MaxUDPSize = 512


### PR DESCRIPTION
Minor fix for Issue-29
ok  	go53/api	0.016s
ok  	go53/api/handlers	0.007s
ok  	go53/cmd/go53ctl	0.004s
?   	go53/cmd/server	[no test files]
ok  	go53/config	0.751s
ok  	go53/distributed	0.008s
ok  	go53/dns	0.004s
ok  	go53/dns/dnsutils	8.333s
ok  	go53/internal	0.002s
ok  	go53/internal/errors	0.001s
ok  	go53/memory	0.003s
ok  	go53/security	0.006s
?   	go53/storage	[no test files]
?   	go53/storage/badger	[no test files]
?   	go53/storage/postgres	[no test files]
FAIL	go53/tools [build failed]
?   	go53/types	[no test files]
ok  	go53/zone	0.002s
ok  	go53/zone/rtypes	0.006s
?   	go53/zonemeta	[no test files]
?   	go53/zonereader	[no test files]