### PR TITLE
Reject queries with multiple OPT records as FORMERR (#30)

### DIFF
--- a/dns/handler.go
+++ b/dns/handler.go
@@ -92,6 +92,14 @@ func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
+	if multipleOPTRecords(r) {
+		slog.Warn("Refusing DNS request carrying more than one OPT record (RFC 6891 §6.1.1)")
+		m.SetRcode(r, dns.RcodeFormatError)
+		m.Authoritative = false
+		writeResponse(w, r, m)
+		return
+	}
+
 	if malformedEDNSCookie(opt) {
 		m.SetRcode(r, dns.RcodeFormatError)
 		m.Authoritative = false
@@ -284,6 +292,19 @@ func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 
 	dnsutils.ApplyNSID(m, r)
 	writeResponse(w, r, m)
+}
+
+func multipleOPTRecords(r *dns.Msg) bool {
+	count := 0
+	for _, rr := range r.Extra {
+		if rr.Header().Rrtype == dns.TypeOPT {
+			count++
+			if count > 1 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func malformedEDNSCookie(opt *dns.OPT) bool {

--- a/dns/handler_test.go
+++ b/dns/handler_test.go
@@ -311,6 +311,32 @@ func TestHandleRequestRejectsMalformedEDNSCookie(t *testing.T) {
 	}
 }
 
+func TestHandleRequestRejectsMultipleOPTRecords(t *testing.T) {
+	resetDNSHandlerTestConfig()
+	req := new(mdns.Msg)
+	req.SetQuestion("example.test.", mdns.TypeA)
+	req.SetEdns0(1232, false)
+
+	secondOPT := new(mdns.OPT)
+	secondOPT.Hdr.Name = "."
+	secondOPT.Hdr.Rrtype = mdns.TypeOPT
+	secondOPT.SetUDPSize(1232)
+	req.Extra = append(req.Extra, secondOPT)
+
+	w := &captureResponseWriter{}
+	handleRequest(w, req)
+
+	if w.msg == nil {
+		t.Fatalf("expected response")
+	}
+	if w.msg.Rcode != mdns.RcodeFormatError {
+		t.Fatalf("rcode = %s, want FORMERR", mdns.RcodeToString[w.msg.Rcode])
+	}
+	if w.msg.Authoritative {
+		t.Fatalf("multiple OPT FORMERR must not be authoritative")
+	}
+}
+
 func TestFinalizeResponseCapsUDPSizeAndTruncates(t *testing.T) {
 	resetDNSHandlerTestConfig()
 	config.AppConfig.Live.MaxUDPSize = 512


### PR DESCRIPTION
RFC 6891 §6.1.1 allows at most one OPT record per message. Detect multiple OPT records and respond FORMERR instead of NOERROR.
ok  	go53/api	(cached)
ok  	go53/api/handlers	(cached)
ok  	go53/cmd/go53ctl	(cached)
?   	go53/cmd/server	[no test files]
ok  	go53/config	(cached)
ok  	go53/distributed	(cached)
ok  	go53/dns	0.004s
ok  	go53/dns/dnsutils	(cached)
ok  	go53/internal	(cached)
ok  	go53/internal/errors	(cached)
ok  	go53/memory	(cached)
ok  	go53/security	(cached)
?   	go53/storage	[no test files]
?   	go53/storage/badger	[no test files]
?   	go53/storage/postgres	[no test files]
?   	go53/types	[no test files]
ok  	go53/zone	(cached)
ok  	go53/zone/rtypes	(cached)
?   	go53/zonemeta	[no test files]
?   	go53/zonereader	[no test files]